### PR TITLE
WDCONGA-18 Removed .conf file copy from main.yml to enable distributi…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,14 +15,15 @@
   include: setup_ssl.yml
   when: "'ssl' in conga_variants"
 
-- name: Copy all CONGA files except vhosts.
+# copy all config files but leave out distribution specific files
+- name: Copy all CONGA files except vhosts and conf
   include_role:
     name: conga-files
   vars:
     base_path: "{{ apache_config_path }}"
     handlers: [ restart apache ]
-    files: "{{ conga_files_paths | select('match', '^(?!vhosts.d/)') | list }}"
-    directories: "{{ conga_directories | select('match', '^(?!vhosts.d)') | list }}"
+    files: "{{ conga_files_paths | select('match', '^(?!(vhosts|conf).d/)') | list }}"
+    directories: "{{ conga_directories | select('match', '^(?!(vhosts|conf).d)') | list }}"
 
 - name: Enable CONGA sites.
   include: "enable_sites_{{ ansible_os_family }}.yml"

--- a/tasks/setup_Debian.yml
+++ b/tasks/setup_Debian.yml
@@ -23,3 +23,23 @@
   when: "apache_version.split('.')[1] >= '4'"
   notify:
     - restart apache
+
+# Copy conf files from conf.d to conf-available
+- name: Copy conf.d CONGA files to conf-available.
+  include_role:
+    name: conga-files
+  vars:
+    base_path: "{{ apache_config_path }}/conf-available"
+    strip: "conf.d/"
+    handlers: [ restart apache ]
+    files: "{{ conga_files_paths | select('match', '^conf.d/.*') | list }}"
+    directories: []
+
+# enable all configuration files that were copied to conf-available
+- name: Enable CONGA Apache configurations.
+  command: a2enconf {{ item | basename }}
+  args:
+    creates: "{{ apache_config_path }}/conf-enabled/{{ item | basename }}"
+  with_items: "{{ conga_files_paths | select('match', '^conf.d/.*') | list }}"
+  notify:
+    - restart apache

--- a/tasks/setup_RedHat.yml
+++ b/tasks/setup_RedHat.yml
@@ -13,3 +13,13 @@
     create: yes
   notify:
     - restart apache
+
+# copy all conf files from conf.d to conf.d on redhat
+- name: Copy conf.d CONGA files
+  include_role:
+    name: conga-files
+  vars:
+    base_path: "{{ apache_config_path }}"
+    handlers: [ restart apache ]
+    files: "{{ conga_files_paths | select('match', '^conf.d/.*') | list }}"
+    directories: "{{ conga_directories | select('match', '^conf.d/.*') | list }}"


### PR DESCRIPTION
…on specific destinations (conf-available for apache and conf.d for RedHat)

@interatom with https://github.com/wcm-io-devops/ansible-conga-aem-dispatcher/commit/befb6a453bc1f6a4608ec768f5f56671c778af09 the debian configuration of the dispatcher was not placed in the correct folder.

What i changed:
1. Excluded conf.d file copy from common setup process (main.yml)
2. Debian: .conf files are not copied to "conf-available" and enabled via "a2enconf"
3. Redhat: .conf files are copied from "conf.d" to "conf.d" (as before but only for RHEL)

This changed was successful tested on RHEL7 and Debian Stretch with Apache 2.4.