### PR TITLE
Enable apache modules on all supported distributions

### DIFF
--- a/tasks/enable_modules.yml
+++ b/tasks/enable_modules.yml
@@ -1,0 +1,22 @@
+# _apache_version variable was determined during os family specific setup
+- name: Create apache_version variable.
+  set_fact:
+    apache_version: "{{ _apache_version.stdout.split()[2].split('/')[1] }}"
+
+- name: Enable Apache modules required by CONGA role.
+  apache2_module:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ conga_config.httpd.modules }}"
+  when: conga_config.httpd is defined and conga_config.httpd.modules is defined
+  notify:
+    - restart apache
+
+# The CONGA configs still use 2.2 auth syntax so we need to enable the compat module for 2.4+
+- name: Enable Apache access_compat module for Apache 2.4.
+  apache2_module:
+    name: access_compat
+    state: present
+  when: "apache_version.split('.')[1] >= '4'"
+  notify:
+    - restart apache

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,29 +4,6 @@
 - name: Include OS-specific setup.
   include: "setup_{{ ansible_os_family }}.yml"
 
-# _apache_version variable was determined during os family specific setup
-- name: Create apache_version variable.
-  set_fact:
-    apache_version: "{{ _apache_version.stdout.split()[2].split('/')[1] }}"
-
-- name: Enable Apache modules required by CONGA role.
-  apache2_module:
-    name: "{{ item }}"
-    state: present
-  with_items: "{{ conga_config.httpd.modules }}"
-  when: conga_config.httpd is defined and conga_config.httpd.modules is defined
-  notify:
-    - restart apache
-
-# The CONGA configs still use 2.2 auth syntax so we need to enable the compat module for 2.4+
-- name: Enable Apache access_compat module for Apache 2.4.
-  apache2_module:
-    name: access_compat
-    state: present
-  when: "apache_version.split('.')[1] >= '4'"
-  notify:
-    - restart apache
-
 - name: Create cache root directory.
   file:
     path: "{{ conga_config.dispatcher.cache.rootPath }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,29 @@
 - name: Include OS-specific setup.
   include: "setup_{{ ansible_os_family }}.yml"
 
+# _apache_version variable was determined during os family specific setup
+- name: Create apache_version variable.
+  set_fact:
+    apache_version: "{{ _apache_version.stdout.split()[2].split('/')[1] }}"
+
+- name: Enable Apache modules required by CONGA role.
+  apache2_module:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ conga_config.httpd.modules }}"
+  when: conga_config.httpd is defined and conga_config.httpd.modules is defined
+  notify:
+    - restart apache
+
+# The CONGA configs still use 2.2 auth syntax so we need to enable the compat module for 2.4+
+- name: Enable Apache access_compat module for Apache 2.4.
+  apache2_module:
+    name: access_compat
+    state: present
+  when: "apache_version.split('.')[1] >= '4'"
+  notify:
+    - restart apache
+
 - name: Create cache root directory.
   file:
     path: "{{ conga_config.dispatcher.cache.rootPath }}"

--- a/tasks/setup_Debian.yml
+++ b/tasks/setup_Debian.yml
@@ -2,28 +2,6 @@
   shell: "apachectl -v"
   register: _apache_version
 
-- name: Create apache_version variable.
-  set_fact:
-    apache_version: "{{ _apache_version.stdout.split()[2].split('/')[1] }}"
-
-- name: Enable Apache modules required by CONGA role.
-  apache2_module:
-    name: "{{ item }}"
-    state: present
-  with_items: "{{ conga_config.httpd.modules }}"
-  when: conga_config.httpd is defined and conga_config.httpd.modules is defined
-  notify:
-    - restart apache
-
-# The CONGA configs still use 2.2 auth syntax so we need to enable the compat module for 2.4+
-- name: Enable Apache access_compat module for Apache 2.4.
-  apache2_module:
-    name: access_compat
-    state: present
-  when: "apache_version.split('.')[1] >= '4'"
-  notify:
-    - restart apache
-
 # Copy conf files from conf.d to conf-available
 - name: Copy conf.d CONGA files to conf-available.
   include_role:

--- a/tasks/setup_Debian.yml
+++ b/tasks/setup_Debian.yml
@@ -2,6 +2,9 @@
   shell: "apachectl -v"
   register: _apache_version
 
+- name: Include httpd module setup.
+  include: "enable_modules.yml"
+
 # Copy conf files from conf.d to conf-available
 - name: Copy conf.d CONGA files to conf-available.
   include_role:

--- a/tasks/setup_RedHat.yml
+++ b/tasks/setup_RedHat.yml
@@ -1,3 +1,7 @@
+- name: Get installed version of Apache.
+  shell: "httpd -v"
+  register: _apache_version
+
 # Shims for Debian compatibility
 - name: Create /etc/ssl/private link for SSL key files.
   file:

--- a/tasks/setup_RedHat.yml
+++ b/tasks/setup_RedHat.yml
@@ -2,6 +2,9 @@
   shell: "httpd -v"
   register: _apache_version
 
+- name: Include httpd module setup.
+  include: "enable_modules.yml"
+
 # Shims for Debian compatibility
 - name: Create /etc/ssl/private link for SSL key files.
   file:


### PR DESCRIPTION
In the current version only for the debian family the apache modules are enabled.