### PR TITLE
Improve symlinking at /etc/ssl/private on RedHat

### DIFF
--- a/tasks/setup_RedHat.yml
+++ b/tasks/setup_RedHat.yml
@@ -1,14 +1,15 @@
 # Shims for Debian compatibility
-- block:
-  - name: Make sure /etc/ssl/private exists.
-    path: /etc/ssl/private
-    state: directory
-    mode: '0755'
-  - name: Create /etc/ssl/private link for SSL key files.
-    file:
-      src: /etc/pki/tls/private/*
-      dest: /etc/ssl/private/
-      state: link
+- name: Symlink SSL cert path to /etc/ssl/private.
+  block:
+    - name: Make sure /etc/ssl/private exists.
+      path: /etc/ssl/private
+      state: directory
+      mode: '0755'
+    - name: Create /etc/ssl/private link for SSL key files.
+      file:
+        src: /etc/pki/tls/private/*
+        dest: /etc/ssl/private/
+        state: link
   when: "'ssl' in conga_variants"
 
 - name: Set APACHE_LOG_DIR variable.

--- a/tasks/setup_RedHat.yml
+++ b/tasks/setup_RedHat.yml
@@ -7,9 +7,11 @@
       mode: '0755'
   - name: Create /etc/ssl/private link for SSL key files.
     file:
-      src: /etc/pki/tls/private/*
+      src: "{{ item }}"
       dest: /etc/ssl/private/
       state: link
+    with_fileglob:
+      - "/etc/pki/tls/private/*"
   when: "'ssl' in conga_variants"
 
 - name: Set APACHE_LOG_DIR variable.

--- a/tasks/setup_RedHat.yml
+++ b/tasks/setup_RedHat.yml
@@ -1,15 +1,15 @@
 # Shims for Debian compatibility
-- name: Symlink SSL cert path to /etc/ssl/private.
-  block:
-    - name: Make sure /etc/ssl/private exists.
+- block:
+  - name: Make sure /etc/ssl/private exists.
+    file:
       path: /etc/ssl/private
       state: directory
       mode: '0755'
-    - name: Create /etc/ssl/private link for SSL key files.
-      file:
-        src: /etc/pki/tls/private/*
-        dest: /etc/ssl/private/
-        state: link
+  - name: Create /etc/ssl/private link for SSL key files.
+    file:
+      src: /etc/pki/tls/private/*
+      dest: /etc/ssl/private/
+      state: link
   when: "'ssl' in conga_variants"
 
 - name: Set APACHE_LOG_DIR variable.

--- a/tasks/setup_RedHat.yml
+++ b/tasks/setup_RedHat.yml
@@ -1,9 +1,14 @@
 # Shims for Debian compatibility
-- name: Create /etc/ssl/private link for SSL key files.
-  file:
-    src: /etc/pki/tls/private
-    dest: /etc/ssl/private
-    state: link
+- block:
+  - name: Make sure /etc/ssl/private exists.
+    path: /etc/ssl/private
+    state: directory
+    mode: '0755'
+  - name: Create /etc/ssl/private link for SSL key files.
+    file:
+      src: /etc/pki/tls/private/*
+      dest: /etc/ssl/private/
+      state: link
   when: "'ssl' in conga_variants"
 
 - name: Set APACHE_LOG_DIR variable.


### PR DESCRIPTION
This fixes a bug that leads to a crash occurring when /etc/ssl/private is already existent, which is the case for example when Puppet is used to provision certificates.