### PR TITLE
Fix "Add SSL CA certificate to list" task

### DIFF
--- a/tasks/setup_ssl_files.yml
+++ b/tasks/setup_ssl_files.yml
@@ -5,11 +5,10 @@
       - "{{ tenant.config.httpd.ssl.certificateKeyFile }}"
 
 # CA certificate is optional
-- block:
-  - name: Add SSL CA certificate to list.
-    set_fact:
-      ssl_files: "{{ ssl_files + [ tenant.config.httpd.ssl.caCertificateFile ] }}"
-  when: tenant.config.httpd.ssl.caCertificateFile is defined
+- name: Add SSL CA certificate to list.
+  set_fact:
+    ssl_files: "{{ ssl_files + [ tenant.config.httpd.ssl.caCertificateFile ] }}"
+  when: tenant.config.httpd.ssl.caCertificateFile
 
 - name: Copy SSL files.
   copy:


### PR DESCRIPTION
When `tenant.config.httpd.ssl.caCertificateFile` is not defined, Ansible will add `null` to the list which causes the subsequent task to fail.
Also, the `block` made so sense here.